### PR TITLE
[WIP] Add support for throttle per host config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules/
+docker/
+images/
+README.md

--- a/lib/args.js
+++ b/lib/args.js
@@ -46,6 +46,11 @@ program
     DEFAULT_PAC_PORT
   )
   .option(
+    '    --urls-config-path <s>',
+    'path to file with throttle config for specific URLs (JSON)',
+    null
+  )
+  .option(
     '-v, --verbose',
     'cause throttle-proxy to be verbose'
   )

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,13 +1,31 @@
+const fs = require('fs');
+const path = require('path');
 const args = require('./args');
 const proxy = require('./proxy');
 const proxyAutoConfig = require('./proxy-auto-config');
 
-proxy({
+function getUrlsConfig() {
+  if (!args.urlsConfigPath) {
+    return [];
+  }
+
+  try {
+    const content = fs.readFileSync(path.resolve(process.cwd(), args.urlsConfigPath)).toString();
+    return JSON.parse(content);
+  } catch (_err) {}
+
+  return [];
+}
+
+const config = {
   port: args.port,
   incomingSpeed: args.incomingSpeed,
   outgoingSpeed: args.outgoingSpeed,
-  delay: args.delay
-});
+  delay: args.delay,
+  urlsConfig: getUrlsConfig()
+};
+
+proxy(config);
 
 if (args.pacPort) {
   proxyAutoConfig({

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -10,10 +10,10 @@ const createProxyServer = require('./proxy/server');
  * @param {Number} options.delay in ms
  * @return {net.Server}
  */
-module.exports = options => {
+module.exports = async options => {
   debug(options);
 
-  const proxy = createProxyServer(options);
+  const proxy = await createProxyServer(options);
 
   return proxy
     .on('error', err => {

--- a/lib/proxy/handler.js
+++ b/lib/proxy/handler.js
@@ -1,3 +1,4 @@
+const { resolve } = require('dns').promises;
 const debug = require('debug')('throttle-proxy:handler');
 const socks = require('socks-handler');
 const Channel = require('./throttle');
@@ -45,13 +46,63 @@ function createVersionedReply(version) {
   }
 }
 
-module.exports = options => {
-  const inputChannel = new Channel(options.incomingSpeed);
-  const outputChannel = new Channel(options.outgoingSpeed);
+module.exports = async options => {
+  const channels = {
+    [options.incomingSpeed]: new Channel(options.incomingSpeed),
+    [options.outgoingSpeed]: new Channel(options.outgoingSpeed),
+    Infinity: new Channel(Infinity),
+  };
+
+  // Initialize channels, resolve DNS to speed up request processing.
+  for (const urlConfig of options.urlsConfig) {
+    if (urlConfig.incomingSpeed && !channels[urlConfig.incomingSpeed]) channels[urlConfig.incomingSpeed] = new Channel(urlConfig.incomingSpeed);
+    if (urlConfig.outgoingSpeed && !channels[urlConfig.outgoingSpeed]) channels[urlConfig.outgoingSpeed] = new Channel(urlConfig.outgoingSpeed);
+
+    // Resolve IP for URL to match by IP if we receive IP by Sock protocol.
+    try {
+      urlConfig.ips = await resolve(new URL(urlConfig.url).host, 'A')
+    } catch (_err) {
+      debug(`can't resolve IPs for ${urlConfig.url}`);
+    }
+  }
+
+  /**
+   * Try to find configuration for host:port.
+   *
+   * @param {string} host Host
+   * @param {string} port Port
+   * @returns {object} Config
+   */
+  const getConfigForHost = (host, port) => {
+    const isReqHostIP = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.test(host); // Check DST address is IPv4.
+
+    return options.urlsConfig.find(({ url, ips }) => {
+      const parsedUrl = new URL(url);
+
+      return (isReqHostIP ? (ips || []).some(ip => ip === host) : parsedUrl.host === host)
+        && (Number(port) === (parsedUrl.protocol === 'https:' ? 443 : 80))
+    }) || {};
+  }
+
+  const createChannelsForHost = (host, port) => {
+    if (!options.urlsConfig.length) {
+      return { 
+        in: channels[options.incomingSpeed],
+        out: channels[options.outgoingSpeed]
+      };
+    }
+
+    const config = getConfigForHost(host, port);
+
+    return {
+        in: channels[config.incomingSpeed || options.incomingSpeed],
+        out: channels[config.outgoingSpeed || options.outgoingSpeed]
+    };
+  }
 
   return clientConnection => (
     (arg, callback) => {
-      const {version, command, host, port} = arg;
+      let {version, command, host, port} = arg;
       const doReply = createVersionedReply(version)(callback);
 
       // only "CONNECT" command is supported
@@ -65,13 +116,12 @@ module.exports = options => {
       debug(`connect to ${host}:${port}`);
 
       const upstream = createUpstream({host, port, timeout: 3000});
-      const inputThrottle = inputChannel.createThrottle();
-      const outputThrottle = outputChannel.createThrottle();
+      const channels = createChannelsForHost(host, port);
 
       clientConnection
-        .pipe(outputThrottle)
+        .pipe(channels.out.createThrottle())
         .pipe(upstream)
-        .pipe(inputThrottle)
+        .pipe(channels.in.createThrottle())
         .pipe(clientConnection);
 
       function onConnectError(err) {

--- a/lib/proxy/server.js
+++ b/lib/proxy/server.js
@@ -11,8 +11,8 @@ const handlerFactory = require('./handler');
  * @param {Number} options.outgoingSpeed in bytes per second
  * @param {Number} options.delay in ms
  */
-module.exports = options => {
-  const handler = handlerFactory(options);
+module.exports = async options => {
+  const handler = await handlerFactory(options);
 
   return net.createServer(clientConnection => {
     clientConnection


### PR DESCRIPTION
SOCKS5 supports domain and port in `CONNECT` message, so full URL match impossible. 
⚠️ SOCKS4 supports only IP address for destination address and here we match by IP :)

Option: `--urls-config-path`.

Config file example:
```json
[
  { "url": "https://github.com", "incomingSpeed": 3000, "outcomingSpeed": 10000 }
]
```

References:
* [SOCKS5 spec](https://tools.ietf.org/html/rfc1928)

Alternatives:
* Maybe MITM proxy.
* Charles web proxy.